### PR TITLE
Handle MDX 2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,11 @@
 repos:
-  - repo: https://github.com/prettier/prettier
-    rev: '2.0.5'
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: 'v2.6.2'
     hooks:
       - id: prettier
+        additional_dependencies:
+          - 'prettier@2.5.1'
+          - '@carbonplan/prettier@1.2.0'
         files: "\\.(\
           css|less|scss\
           |graphql|gql\
@@ -13,10 +16,13 @@ repos:
           |vue\
           |yaml|yml\
           )$"
-  - repo: https://github.com/prettier/prettier
-    rev: '2.0.5'
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: 'v2.6.2'
     hooks:
       - id: prettier
+        additional_dependencies:
+          - 'prettier@2.5.1'
+          - '@carbonplan/prettier@1.2.0'
         name: prettier-markdown
         entry: prettier --write --parser mdx
         files: "\\.(\

--- a/index.js
+++ b/index.js
@@ -219,7 +219,7 @@ module.exports = {
         color: 'secondary',
       },
     },
-    inlineCode: {
+    code: {
       px: [1],
       pb: ['3px'],
       pt: ['1px'],

--- a/index.js
+++ b/index.js
@@ -1,10 +1,8 @@
 module.exports = {
   space: [0, 4, 8, 16, 24, 32, 48, 64, 96, 128, 172, 256, 512],
   fonts: {
-    body:
-      'relative-book-pro, Roboto, system-ui, -apple-system, BlinkMacSystemFont',
-    faux:
-      'relative-faux-book-pro, Roboto, system-ui, -apple-system, BlinkMacSystemFont',
+    body: 'relative-book-pro, Roboto, system-ui, -apple-system, BlinkMacSystemFont',
+    faux: 'relative-faux-book-pro, Roboto, system-ui, -apple-system, BlinkMacSystemFont',
     heading:
       'relative-medium-pro, Roboto, system-ui, -apple-system, BlinkMacSystemFont',
     mono: 'relative-mono-11-pitch-pro, Menlo, monospace',

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,20 @@
       "version": "7.0.0",
       "license": "MIT",
       "devDependencies": {
-        "prettier": "^2.2.1"
+        "@carbonplan/prettier": "^1.2.0",
+        "prettier": "2.3.0"
       }
     },
+    "node_modules/@carbonplan/prettier": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@carbonplan/prettier/-/prettier-1.2.0.tgz",
+      "integrity": "sha512-ASisVvxKrKOctvolBvjxcsQU+/Va+JIRmjaHnkPCsGz8jfg4eFdFG/GfLI+gLn9sAx/Z0DBrGthhOgHUBLxE0Q==",
+      "dev": true
+    },
     "node_modules/prettier": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
-      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
+      "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -26,10 +33,16 @@
     }
   },
   "dependencies": {
+    "@carbonplan/prettier": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@carbonplan/prettier/-/prettier-1.2.0.tgz",
+      "integrity": "sha512-ASisVvxKrKOctvolBvjxcsQU+/Va+JIRmjaHnkPCsGz8jfg4eFdFG/GfLI+gLn9sAx/Z0DBrGthhOgHUBLxE0Q==",
+      "dev": true
+    },
     "prettier": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
-      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
+      "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
       "dev": true
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@carbonplan/theme",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@carbonplan/theme",
-      "version": "7.0.0",
+      "version": "8.0.0",
       "license": "MIT",
       "devDependencies": {
         "@carbonplan/prettier": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carbonplan/theme",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "description": "theme for styling our websites",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,10 @@
   "bugs": {
     "url": "https://github.com/carbonplan/theme/issues"
   },
+  "prettier": "@carbonplan/prettier",
   "devDependencies": {
-    "prettier": "^2.2.1"
+    "@carbonplan/prettier": "^1.2.0",
+    "prettier": "2.3.0"
   },
   "homepage": "https://github.com/carbonplan/theme#readme"
 }


### PR DESCRIPTION
- Transfer styles from `inlineCode` -> `code`, which will continue to be picked up by inline code using an ``` `inline reference` ```
- From the [MDX 2 migration guide](https://mdxjs.com/migrating/v2/#update-mdx-content):
  > The special component name `inlineCode` was removed, we recommend to use `pre` for the block version of code, and `code` for both the block and inline versions
- Works in tandem with https://github.com/carbonplan/prism/pull/34